### PR TITLE
Offline icons

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -9,6 +9,7 @@ export default withMermaid(
   base: process.env.VITEPRESS_BASE || '/',
   srcDir: './src',
   head: [
+    ['link', { rel: 'stylesheet', href: '@mdi/font/css/materialdesignicons.css' }],
     ['link', { rel: 'icon', href: 'https://ubc-art-and-justice.github.io/digital-literacy/logo.png' }],
     ['meta', { property: 'og:image', content: 'https://ubc-art-and-justice.github.io/digital-literacy/social-share.png' }]
   ],

--- a/docs/.vitepress/theme/components/VitepressCard.vue
+++ b/docs/.vitepress/theme/components/VitepressCard.vue
@@ -2,13 +2,13 @@
   <div class="card">
     <p class="text-with-icon">
       <Icon
-        :icon="icon"
+        v-if="resolvedIcon"
+        :icon="resolvedIcon"
         width="1.2em"
         height="1.2em"
-        v-if="icon"
         :style="{ color: iconColor }"
       />
-      <span :class="['title', { 'no-icon': !icon }]">{{ title }}</span>
+      <span :class="['title', { 'no-icon': !resolvedIcon }]">{{ title }}</span>
     </p>
     <div class="card-body">
       <slot />
@@ -22,6 +22,7 @@
 
 <script>
 import { Icon } from "@iconify/vue";
+import { computed } from 'vue';
 
 export default {
   name: "VitepressCard",
@@ -30,6 +31,10 @@ export default {
   },
   props: {
     icon: {
+      type: String,
+      default: "",
+    },
+    mdiIcon: {
       type: String,
       default: "",
     },
@@ -50,10 +55,22 @@ export default {
       default: "Check it out",
     },
   },
-  computed: {
-    actualLinkText() {
-      return this.linkText || "Check it out";
-    },
+  setup(props) {
+    const resolvedIcon = computed(() => {
+      if (props.mdiIcon) {
+        return `mdi:${props.mdiIcon}`;
+      }
+      return props.icon || "";
+    });
+
+    const actualLinkText = computed(() => {
+      return props.linkText || "Check it out";
+    });
+
+    return {
+      resolvedIcon,
+      actualLinkText,
+    };
   },
 };
 </script>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -2,6 +2,7 @@
 import { h } from 'vue'
 import type { Theme } from 'vitepress'
 import DefaultTheme from 'vitepress/theme'
+import '@mdi/font/css/materialdesignicons.css'
 import './style.css'
 import './custom.css'
 import { Icon } from '@iconify/vue';              // Iconify

--- a/docs/src/1-tablet-navigation/index.md
+++ b/docs/src/1-tablet-navigation/index.md
@@ -8,7 +8,7 @@ This unit of the course is tablet-specific because the primary use of this conte
 
 <VitepressCardContainer :cols="2">
     <VitepressCard
-        icon="mdi:about-circle"
+        mdiIcon="about-circle"
         iconColor="var(--vp-c-brand-2)"
         title="1.1 The Basics"
         link="./1.1-basics"
@@ -17,7 +17,7 @@ This unit of the course is tablet-specific because the primary use of this conte
         This section covers the very basics of navigating your tablet. 
     </VitepressCard>
     <VitepressCard
-        icon="mdi:tablet"
+        mdiIcon="cog"
         iconColor="var(--vp-c-brand-2)"
         title="1.2 Features and Settings"
         link="./1.2-tablet-features"
@@ -26,7 +26,7 @@ This unit of the course is tablet-specific because the primary use of this conte
         This section covers some tablet features such as the keyboard, icons, and accessibility settings.
     </VitepressCard>
     <VitepressCard
-        icon="mdi:do-not-disturb-alt"
+        mdiIcon="minus-circle"
         iconColor="var(--vp-c-brand-2)"
         title="1.3 Restrictions"
         link="./1.3-restrictions"
@@ -35,7 +35,7 @@ This unit of the course is tablet-specific because the primary use of this conte
         Some features of the tablet are disabled and this section explains them. 
     </VitepressCard>
     <VitepressCard
-        icon="mdi:navigation-variant-outline"
+        mdiIcon="arrow-right-bold-box"
         iconColor="var(--vp-c-brand-2)"
         title="1.4 Content Navigation"
         link="./1.4-content-navigation"

--- a/docs/src/2-apps-and-internet/index.md
+++ b/docs/src/2-apps-and-internet/index.md
@@ -21,7 +21,7 @@ However, the information in this section may still be useful to you! You can use
 
 <VitepressCardContainer :cols="2">
   <VitepressCard
-    icon="mdi:internet"
+    mdiIcon="web"
     iconColor="var(--vp-c-brand-2)"
     title="The Internet"
     link="./2.1-the-internet"
@@ -30,7 +30,7 @@ However, the information in this section may still be useful to you! You can use
   This section explains what the internet is and how to connect to it.
   </VitepressCard>
   <VitepressCard
-    icon="mdi:link-box-variant"
+    mdiIcon="link-box"
     iconColor="var(--vp-c-brand-2)"
     title="Websites"
     link="./2.2-websites"
@@ -39,7 +39,7 @@ However, the information in this section may still be useful to you! You can use
   This section discusses websites, web pages, web addresses, and links.
   </VitepressCard>
   <VitepressCard
-    icon="mdi:search"
+    mdiIcon="magnify"
     iconColor="var(--vp-c-brand-2)"
     title="Searching"
     link="./2.3-searching"
@@ -48,7 +48,7 @@ However, the information in this section may still be useful to you! You can use
   This section explains what it means to search the internet, and how to make a search.
   </VitepressCard>
   <VitepressCard
-    icon="mdi:star"
+    mdiIcon="star-circle"
     iconColor="var(--vp-c-brand-2)"
     title="Browser Features"
     link="./2.4-browser-features"
@@ -57,7 +57,7 @@ However, the information in this section may still be useful to you! You can use
   This section summarizes some common features of web browsers that assist with navigating the internet.
   </VitepressCard>
   <VitepressCard
-    icon="mdi:question-mark-rhombus"
+    mdiIcon="help-rhombus"
     iconColor="var(--vp-c-brand-2)"
     title="Reputable Sources"
     link="./2.5-reputable-sources"
@@ -66,7 +66,7 @@ However, the information in this section may still be useful to you! You can use
   This section covers some ways of determining whether a source is reliable.
   </VitepressCard>
   <VitepressCard
-    icon="mdi:apps"
+    mdiIcon="apps"
     iconColor="var(--vp-c-brand-2)"
     title="Apps"
     link="./2.6-apps"

--- a/docs/src/3-file-system/index.md
+++ b/docs/src/3-file-system/index.md
@@ -8,7 +8,7 @@ In this unit, you will learn about files. This includes organizing, saving, nami
 
 <VitepressCardContainer :cols="2">
   <VitepressCard
-    icon="mdi:file"
+    mdiIcon="file"
     iconColor="var(--vp-c-brand-2)"
     title="Files"
     link="./3.1-files"
@@ -17,7 +17,7 @@ In this unit, you will learn about files. This includes organizing, saving, nami
   This section explains what files are, goes over some common types of files, and introduces the concept of file size.
   </VitepressCard>
   <VitepressCard
-    icon="mdi:folder"
+    mdiIcon="folder"
     iconColor="var(--vp-c-brand-2)"
     title="Folders"
     link="./3.2-folders"
@@ -26,7 +26,7 @@ In this unit, you will learn about files. This includes organizing, saving, nami
   This section explains what folders are and how they are used to organize files.
   </VitepressCard>
   <VitepressCard
-    icon="mdi:content-save-check"
+    mdiIcon="content-save-check"
     iconColor="var(--vp-c-brand-2)"
     title="Saving Files"
     link="./3.3-saving-files"
@@ -35,7 +35,7 @@ In this unit, you will learn about files. This includes organizing, saving, nami
   This section covers the process of saving files.
   </VitepressCard>
   <VitepressCard
-    icon="mdi:folder-shared"
+    mdiIcon="folder-account"
     iconColor="var(--vp-c-brand-2)"
     title="Sharing Files"
     link="./3.4-sharing-files"

--- a/docs/src/4-staying-safe/index.md
+++ b/docs/src/4-staying-safe/index.md
@@ -32,7 +32,7 @@ Sometimes it's just cool to know how things work!
 
 <VitepressCardContainer :cols="2">
   <VitepressCard
-    icon="ic:round-update"
+    mdiIcon="update"
     iconColor="var(--vp-c-brand-2)"
     title="Updates"
     link="./4.1-updates"
@@ -41,7 +41,7 @@ Sometimes it's just cool to know how things work!
   This section covers what updates are, why they are important, and how to install them.
   </VitepressCard>
   <VitepressCard
-    icon="ic:twotone-lock"
+    mdiIcon="form-textbox-password"
     iconColor="var(--vp-c-brand-2)"
     title="Passwords"
     link="./4.2-passwords"
@@ -50,7 +50,7 @@ Sometimes it's just cool to know how things work!
   This section covers what passwords are and what makes a 'good' password.
   </VitepressCard>
   <VitepressCard
-    icon="mdi:encryption-outline"
+    mdiIcon="lock-check"
     iconColor="var(--vp-c-brand-2)"
     title="Encryption"
     link="./4.3-encryption"
@@ -59,7 +59,7 @@ Sometimes it's just cool to know how things work!
   This section covers what encryption is, and how it can help keep your information safe.
   </VitepressCard>
   <VitepressCard
-    icon="ph:virus-duotone"
+    mdiIcon="virus"
     iconColor="var(--vp-c-brand-2)"
     title="Viruses"
     link="./4.4-viruses"
@@ -68,7 +68,7 @@ Sometimes it's just cool to know how things work!
   This section covers what viruses are, and how to protect your computer from them.
   </VitepressCard>
   <VitepressCard
-    icon="mdi:internet"
+    mdiIcon="web"
     iconColor="var(--vp-c-brand-2)"
     title="Internet Safety"
     link="./4.5-internet-safety"

--- a/docs/src/5-communication/index.md
+++ b/docs/src/5-communication/index.md
@@ -10,7 +10,7 @@ This section covers different ways of using technology to communicate with other
 
 <VitepressCardContainer :cols="2">
   <VitepressCard
-    icon="mdi:email-fast"
+    mdiIcon="email-fast"
     iconColor="var(--vp-c-brand-2)"
     title="Email"
     link="./5.1-email"
@@ -19,7 +19,7 @@ This section covers different ways of using technology to communicate with other
   This section explains what an email is, how to write and send an email, and other email-related topics.
   </VitepressCard>
   <VitepressCard
-    icon="mdi:comment-text"
+    mdiIcon="comment-text"
     iconColor="var(--vp-c-brand-2)"
     title="Texting"
     link="./5.2-texting"
@@ -28,7 +28,7 @@ This section covers different ways of using technology to communicate with other
   This section covers the concepts of texting, abbreviations, emojis, contacts, and phone numbers.
   </VitepressCard>
   <VitepressCard
-    icon="mdi:message-reply-outline"
+    mdiIcon="forum-outline"
     iconColor="var(--vp-c-brand-2)"
     title="Direct Messages"
     link="./5.3-direct-message"
@@ -37,7 +37,7 @@ This section covers different ways of using technology to communicate with other
   This section explains what direct messages are and how they differ from texts.
   </VitepressCard>
   <VitepressCard
-    icon="mdi:video-call"
+    mdiIcon="video-plus"
     iconColor="var(--vp-c-brand-2)"
     title="Video Calls"
     link="./5.4-video-calls"
@@ -46,7 +46,7 @@ This section covers different ways of using technology to communicate with other
   This section covers the purpose and features of video calls.
   </VitepressCard>
   <VitepressCard
-    icon="mdi:people-outline"
+    mdiIcon="account-multiple-outline"
     iconColor="var(--vp-c-brand-2)"
     title="Social Media"
     link="./5.5-social-media"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -47,7 +47,7 @@ This is an arts based initiative by the UBC A.R.T. & Justice Research Project gr
     This section covers the basics of using a tablet, including the keyboard, terminology, icons, and accessibility.
   </VitepressCard>
   <VitepressCard
-    icon="uim:apps"
+    mdiIcon="apps"
     iconColor="var(--vp-c-brand-2)"
     title="Apps and the Internet"
     link="./2-apps-and-internet/index"
@@ -56,7 +56,7 @@ This is an arts based initiative by the UBC A.R.T. & Justice Research Project gr
     This section covers connecting to the internet, navigating websites, browsers and search engines, and apps.
   </VitepressCard>
   <VitepressCard
-    icon="ph:files-duotone"
+    mdiIcon="folder"
     iconColor="var(--vp-c-brand-2)"
     title="Files"
     link="./3-file-system/index"
@@ -65,7 +65,7 @@ This is an arts based initiative by the UBC A.R.T. & Justice Research Project gr
     This section covers what files and folders are, and how to save or share files.
   </VitepressCard>
   <VitepressCard
-    icon="ic:twotone-security"
+    mdiIcon="shield-alert"
     iconColor="var(--vp-c-brand-2)"
     title="Staying Safe"
     link="./4-staying-safe/index"
@@ -74,7 +74,7 @@ This is an arts based initiative by the UBC A.R.T. & Justice Research Project gr
     This section covers updates, passwords, encryption, viruses, and internet safety.
   </VitepressCard>
   <VitepressCard
-    icon="ph:chats-duotone"
+    mdiIcon="forum-outline"
     iconColor="var(--vp-c-brand-2)"
     title="Communication"
     link="./5-communication/index"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -29,7 +29,7 @@ This is an arts based initiative by the UBC A.R.T. & Justice Research Project gr
 
 <VitepressCardContainer :cols="2">
   <VitepressCard
-    icon="icon-park-twotone:new-computer"
+    mdiIcon="monitor-cellphone"
     iconColor="var(--vp-c-brand-2)"
     title="Introduction"
     link="./tech-terror-experience"
@@ -38,7 +38,7 @@ This is an arts based initiative by the UBC A.R.T. & Justice Research Project gr
     This page contains one person's story and experience with encountering new technology after being in prison.
   </VitepressCard>
   <VitepressCard
-    icon="ant-design:tablet-twotone"
+    mdiIcon="cellphone"
     iconColor="var(--vp-c-brand-2)"
     title="Navigating Your Tablet"
     link="./1-tablet-navigation/index"

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@capacitor/assets": "^3.0.5",
         "@capacitor/cli": "^6.1.2",
         "@iconify/vue": "^4.1.2",
+        "@mdi/font": "^7.4.47",
         "mermaid": "^11.2.1",
         "vitepress": "^1.3.2",
         "vitepress-plugin-mermaid": "^2.0.17",
@@ -1349,6 +1350,12 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
+    },
+    "node_modules/@mdi/font": {
+      "version": "7.4.47",
+      "resolved": "https://registry.npmjs.org/@mdi/font/-/font-7.4.47.tgz",
+      "integrity": "sha512-43MtGpd585SNzHZPcYowu/84Vz2a2g31TvPMTm9uTiCSWzaheQySUcSyUH/46fPnuPQWof2yd0pGBtzee/IQWw==",
+      "dev": true
     },
     "node_modules/@mermaid-js/mermaid-mindmap": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "@capacitor/assets": "^3.0.5",
     "@capacitor/cli": "^6.1.2",
     "@iconify/vue": "^4.1.2",
+    "@mdi/font": "^7.4.47",
     "mermaid": "^11.2.1",
     "vitepress": "^1.3.2",
     "vitepress-plugin-mermaid": "^2.0.17",


### PR DESCRIPTION
Previously we used Iconify, which fetches icons on demand:

https://iconify.design/docs/iconify-icon/#icon-data-on-demand

This is not compatible with our offline only app.

Changes:

- Material Design Icons added
- Vitepress Card component updated
- current icons updated

Usage:

- Using the old `icon=` property will use Iconify, as before
- Using the new `mdiIcon=` property will use MDI

For example:

``` diff
<VitepressCard
-    icon="mdi:about-circle"
+    mdiIcon="about-circle"
    ...
```